### PR TITLE
Do not consider a labeled statement as valid code

### DIFF
--- a/no-commented-out-code.js
+++ b/no-commented-out-code.js
@@ -18,6 +18,15 @@ console.assert(isSingleWord('click'));
 console.assert(isSingleWord('browser-specific'));
 console.assert(!isSingleWord('var bar'));
 
+function isLabeledStatement(ast) {
+  'use strict';
+  if (!(ast && ast.body)) {
+    return false;
+  }
+  var firstNodeType = ast.body[0].type;
+  return firstNodeType === 'LabeledStatement';
+}
+
 function isValidCode(text) {
   'use strict';
   if (isSingleWord(text) || isJshint(text)) {
@@ -26,6 +35,9 @@ function isValidCode(text) {
 
   try {
     var ast = espree.parse(text);
+    if (isLabeledStatement(ast)) {
+      return false;
+    }
     return !!ast;
   } catch (err) {
     return false;

--- a/test/commented-out-code.js
+++ b/test/commented-out-code.js
@@ -14,3 +14,7 @@ function baz() {
 //
 // click
 // browser-specific
+//
+// Don't count labeled statements as code, since they
+// conflict with comments like "TODO: cleanup"
+// TODO: cleanup


### PR DESCRIPTION
Implement the request from #10.

Two things to note:
1. It wasn't super clear what your preferred way of writing tests in this repo is - can you provide some direction?
2. I had to use `--no-verify` to bypass the pre-commit hook that's installed, because the existing line length in `no-commented-out-code.js` exceeds the max value set in `.eslintrc` (70). Just let me know how you want me to fix that (changing config vs shortening the line lengths).

Feedback welcome :)