### PR TITLE
fix(console.assert): console.assert polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+require('console-assert').browserify()
 
 module.exports = {
   rules: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "Eric Wooley <ericwooley@gmail.com>"
   ],
   "dependencies": {
+    "console-assert": "1.0.0",
     "espree": "3.0.0-alpha-1",
     "quote": "0.4.0"
   },


### PR DESCRIPTION
Hey Gleb,

I love this plugin generally, but have had an issue running it [within Atom](https://github.com/AtomLinter/linter-eslint/issues/941).

![screen shot 2017-07-01 at 8 37 02 am](https://user-images.githubusercontent.com/18919/27763431-7c781864-5e38-11e7-8856-7d81d6aad30f.png)

I was able to fix the errors locally by adding the `console-assert` package (per the linked thread).

Additionally, I was seeing a test fail on commit pre-hook:

```
/eslint-rules/test/long-file.js
  0:0  warning  file line count 110 exceeded line limit 100  no-long-files
```

But I didn't touch that file so I wasn't sure what to do there.

Please let me know if there's anything else you need.

Thanks,

Brekk